### PR TITLE
build: add rust toolchain definition

### DIFF
--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,3 +1,2 @@
 [toolchain]
 channel = "1.82.0"
-targets = ["wasm32-unknown-unknown"]

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,2 +1,2 @@
 [toolchain]
-channel = "1.82.0"
+channel = "1.83.0"

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,0 +1,3 @@
+[toolchain]
+channel = "1.82.0"
+targets = ["wasm32-unknown-unknown"]


### PR DESCRIPTION
I noticed in #1 that you mentioned that you forgot that you had `nightly` rust set as your default, and I thought I could contribute a `rust-toolchain.toml` definition to help prevent that type of issue going forward.

I took a look at the github action job that you have defined and didn't see anywhere that explicitly sets up a rust version, so I'm not 100% sure that this will play perfectly well with the current `rust.yml` workflow, but I would be happy to contribute a fix for that to have the action install the correct rust version as part of the workflow if needed.

Cheers!