### PR TITLE
Add MSRV with ci test (use egui MSRV of 1.80)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,6 +9,7 @@ description = "Grid, Flexbox, Block layout support for egui using taffy"
 keywords = ["egui", "flexbox", "taffy", "layout", "ui"]
 categories = ["gui"]
 license = "MIT"
+rust-version = "1.81"
 
 [dependencies]
 egui = { version = "0.30", default-features = false }

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,2 +1,2 @@
 [toolchain]
-channel = "1.83.0"
+channel = "1.81"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -532,7 +532,7 @@ impl Tui {
         limit: Option<f32>,
         content: impl FnOnce(&mut Ui) -> T,
     ) -> T {
-        let style = params.style.get_or_insert_default();
+        let style = params.style.get_or_insert_with(|| Style::default());
 
         style.overflow = taffy::Point {
             x: taffy::Overflow::Visible,


### PR DESCRIPTION
Rewrite code using rust API stabilized <= MSRV for compatibility.
Add rust-version to toml.
Add github action to install MSRV rust toolchain and run `cargo +toolchain check` for compatibility.

Tested github action on personal repo.

- Before code rewrite: github action failed and logs show error and rust 1.80 toolchain was used  
https://github.com/boxofrox/egui_taffy/actions/runs/12576659346/job/35053061335#step:4:1

- After code rewrite: github action passes and logs show rust 1.80 toolchain was used.  
https://github.com/boxofrox/egui_taffy/actions/runs/12576701003/job/35053156969#step:4:1