### PR TITLE
Introducing `TuiBackground`

### DIFF
--- a/examples/demo.rs
+++ b/examples/demo.rs
@@ -1,13 +1,15 @@
 use eframe::egui::{self, Vec2b};
 use eframe::{App, Frame};
+use egui_taffy::TuiBackground;
 use egui_taffy::{
-    taffy, tid, tui,
+    TuiBuilderLogic, taffy, tid, tui,
     virtual_tui::{VirtualGridRowHelper, VirtualGridRowHelperParams},
-    TuiBuilderLogic,
 };
+use std::rc::Rc;
 use taffy::{
+    Style,
     prelude::{auto, fr, length, min_content, percent, repeat, span},
-    style_helpers, Style,
+    style_helpers,
 };
 
 #[derive(Default)]
@@ -27,6 +29,7 @@ pub struct State {
     show_overflow_demo: bool,
     show_grid_sticky_demo: bool,
     show_virtual_grid_demo: bool,
+    show_background_demo: bool,
 }
 
 impl App for MyApp {
@@ -64,6 +67,8 @@ impl App for MyApp {
         grid_sticky(ctx, state);
 
         virtual_grid_demo(ctx, state);
+
+        background_demo(ctx, state);
     }
 }
 
@@ -100,6 +105,7 @@ fn ui_side_panel(ctx: &egui::Context, state: &mut State) {
                         &mut state.show_grid_sticky_demo,
                     ),
                     ("Virtual grid row demo", &mut state.show_virtual_grid_demo),
+                    ("Background demo", &mut state.show_background_demo),
                 ] {
                     if tui
                         .style(taffy::Style {
@@ -267,13 +273,13 @@ fn flex_grid_demo(ctx: &egui::Context, state: &mut State) {
                     for header in align_list {
                         tui.mut_style(align_flex_content_in_center)
                             .add_with_border(|tui| {
-                                tui.label(format!("{:?}", header));
+                                tui.label(format!("{header:?}"));
                             });
                     }
 
                     for align_item in align_list {
                         tui.add_with_border(|tui| {
-                            tui.label(format!("{:?}", align_item));
+                            tui.label(format!("{align_item:?}"));
                         });
 
                         for justify_item in align_list {
@@ -286,7 +292,7 @@ fn flex_grid_demo(ctx: &egui::Context, state: &mut State) {
                             })
                             .mut_style(align_flex_content_in_center)
                             .add_with_border(|tui| {
-                                tui.label(format!("{:?} {:?}", align_item, justify_item));
+                                tui.label(format!("{align_item:?} {justify_item:?}"));
                             });
                         }
                     }
@@ -355,7 +361,7 @@ fn grow_demo(ctx: &egui::Context, state: &mut State) {
                             ..default_style()
                         })
                         .add_with_border(|tui| {
-                            tui.label(format!("Grow {}", grow));
+                            tui.label(format!("Grow {grow}"));
                         });
                     }
 
@@ -375,7 +381,7 @@ fn grow_demo(ctx: &egui::Context, state: &mut State) {
                                 ..default_style()
                             })
                             .add_with_border(|tui| {
-                                tui.label(format!("Grow {}", grow));
+                                tui.label(format!("Grow {grow}"));
                             });
                         }
                     });
@@ -437,8 +443,8 @@ fn flex_demo(ctx: &egui::Context, state: &mut State) {
                                 ..Default::default()
                             })
                             .add(|tui| {
-                                tui.label(format!("Justify items: {:?}", justify_content));
-                                tui.label(format!("Flex grow: {:?}", flex_grow));
+                                tui.label(format!("Justify items: {justify_content:?}"));
+                                tui.label(format!("Flex grow: {flex_grow:?}"));
                                 tui.label("Align self:");
                             });
 
@@ -464,7 +470,7 @@ fn flex_demo(ctx: &egui::Context, state: &mut State) {
                                         flex_grow,
                                         ..Default::default()
                                     })
-                                    .ui_add(egui::Button::new(format!("{:?}", align)));
+                                    .ui_add(egui::Button::new(format!("{align:?}")));
                                 }
                             });
                         });
@@ -550,7 +556,7 @@ fn button_demo(ctx: &egui::Context, state: &mut State) {
                                         align_self: Some(taffy::AlignItems::Center),
                                         ..Default::default()
                                     })
-                                    .label(format!("{:?}", align_item));
+                                    .label(format!("{align_item:?}"));
                                 });
                             }
                         });
@@ -585,7 +591,7 @@ fn button_demo(ctx: &egui::Context, state: &mut State) {
                                         align_self: Some(taffy::AlignItems::Center),
                                         ..Default::default()
                                     })
-                                    .label(format!("{:?}", align_item));
+                                    .label(format!("{align_item:?}"));
                                 });
                             }
                         });
@@ -632,7 +638,7 @@ fn overflow_demo(ctx: &egui::Context, state: &mut State) {
                             ..Default::default()
                         })
                         .add_with_border(|tui| {
-                            let label = format!("{:?}", overflow);
+                            let label = format!("{overflow:?}");
                             for _ in 0..50 {
                                 tui.label(&label);
                             }
@@ -692,7 +698,7 @@ fn grid_sticky(ctx: &egui::Context, state: &mut State) {
                                     ..cell_style.clone()
                                 })
                                 .add_with_border(|tui| {
-                                    tui.label(format!("Cell {} {}", i, j));
+                                    tui.label(format!("Cell {i} {j}"));
                                 });
                             }
                         }
@@ -709,8 +715,8 @@ fn grid_sticky(ctx: &egui::Context, state: &mut State) {
 
                                     ..cell_style.clone()
                                 })
-                                .add_with_background(|tui| {
-                                    tui.label(format!("Header {}", i));
+                                .add_with_background_bordered(|tui| {
+                                    tui.label(format!("Header {i}"));
                                 });
                         }
 
@@ -723,7 +729,7 @@ fn grid_sticky(ctx: &egui::Context, state: &mut State) {
                                     ..cell_style.clone()
                                 })
                                 .add_with_background(|tui| {
-                                    tui.label(format!("Row header {}", i));
+                                    tui.label(format!("Row header {i}"));
                                 });
                         }
 
@@ -734,7 +740,7 @@ fn grid_sticky(ctx: &egui::Context, state: &mut State) {
 
                                 ..cell_style.clone()
                             })
-                            .add_with_background(|tui| {
+                            .add_with_background_bordered(|tui| {
                                 tui.label("Top left");
                             });
                     });
@@ -822,7 +828,7 @@ fn virtual_grid_demo(ctx: &egui::Context, state: &mut State) {
                                 ..Default::default()
                             })
                             .id(tid(("header", 1)))
-                            .add_with_background_color(|tui| {
+                            .add_with_background(|tui| {
                                 tui.label("Colspan 2 header");
                             });
 
@@ -835,13 +841,230 @@ fn virtual_grid_demo(ctx: &egui::Context, state: &mut State) {
                                         ..Default::default()
                                     })
                                     .id(tid(("header", ridx, idx)))
-                                    .add_with_background_color(|tui| {
-                                        tui.label(format!("Header {} {}", ridx, idx));
+                                    .add_with_background(|tui| {
+                                        tui.label(format!("Header {ridx} {idx}"));
                                     });
                             }
                         }
                     });
                 });
+        });
+}
+
+fn background_demo(ctx: &egui::Context, state: &mut State) {
+    let params = &mut state.button_params;
+    egui::Window::new("background demo")
+        .open(&mut state.show_background_demo)
+        .default_width(500.)
+        .show(ctx, |ui| {
+            tui(ui, ui.id().with("demo"))
+                .reserve_available_space()
+                .style(taffy::Style {
+                    flex_direction: taffy::FlexDirection::Column,
+                    justify_content: Some(taffy::JustifyContent::Center),
+                    align_items: Some(taffy::AlignItems::Center),
+                    max_size: percent(1.),
+                    size: percent(1.),
+                    gap: length(10.),
+                    ..Default::default()
+                })
+                .show(|tui| {
+                    let box_style = taffy::Style {
+                        size: taffy::Size {
+                            height: length(200.),
+                            width: length(200.),
+                        },
+                        justify_content: Some(taffy::JustifyContent::Center),
+                        align_items: Some(taffy::AlignItems::Center),
+                        padding: length(20.),
+                        ..Default::default()
+                    };
+
+                    let row_style = taffy::Style {
+                        flex_direction: taffy::FlexDirection::Row,
+                        gap: length(10.),
+                        padding: length(10.),
+                        ..Default::default()
+                    };
+
+                    tui.add(|tui| tui.heading("backgrounds".to_uppercase()));
+
+                    tui.style(row_style.clone()).add_with_background_color(
+                        |tui| {
+                            tui.style(box_style.clone()).add_with_background(|tui| {
+                                tui.colored_label(
+                                    egui::Color32::WHITE,
+                                    "bg default".to_uppercase(),
+                                );
+                            });
+
+                            tui.style(box_style.clone())
+                                .add_with_background_bordered(|tui| {
+                                    tui.colored_label(
+                                        egui::Color32::WHITE,
+                                        "bg + border default".to_uppercase(),
+                                    );
+                                });
+
+                            tui.style(box_style.clone()).add_with_background_color(
+                                |tui| {
+                                    tui.colored_label(
+                                        egui::Color32::WHITE,
+                                        "bg transparent".to_uppercase(),
+                                    );
+                                },
+                                egui::Color32::TRANSPARENT,
+                            );
+
+                            tui.style(box_style.clone()).add_with_background_color(
+                                |tui| {
+                                    tui.colored_label(
+                                        egui::Color32::WHITE,
+                                        "bg custom".to_uppercase(),
+                                    );
+                                },
+                                egui::Color32::DARK_GRAY,
+                            );
+
+                            tui.style(box_style.clone()).add_with_background_ext(
+                                |tui| {
+                                    tui.colored_label(egui::Color32::BLACK, "ext 1".to_uppercase());
+                                },
+                                TuiBackground::new()
+                                    .with_background_color(egui::Color32::LIGHT_GRAY)
+                                    .with_border_color(egui::Color32::WHITE)
+                                    .with_border_width(20.)
+                                    .with_corner_radius(egui::CornerRadius::from(40.)),
+                            );
+
+                            tui.style(box_style.clone()).add_with_background_ext(
+                                |tui| {
+                                    tui.colored_label(egui::Color32::WHITE, "ext 2".to_uppercase());
+                                },
+                                TuiBackground::new()
+                                    .with_border()
+                                    .with_border_width(40.)
+                                    .with_corner_radius(200),
+                            );
+                        },
+                        egui::Color32::BLACK,
+                    );
+
+                    tui.add(|tui| tui.heading("buttons".to_uppercase()));
+
+                    tui.style(row_style).add_with_background_color(
+                        |tui| {
+                            let response = tui.style(box_style.clone()).button(|tui| {
+                                tui.colored_label(egui::Color32::WHITE, "button".to_uppercase());
+                            });
+
+                            if response.clicked() {
+                                params.counter += 1;
+                            }
+
+                            let label_selectable = if params.selected {
+                                "selected"
+                            } else {
+                                "selectable"
+                            };
+                            let response =
+                                tui.style(box_style.clone())
+                                    .selectable(params.selected, |tui| {
+                                        tui.colored_label(
+                                            egui::Color32::WHITE,
+                                            label_selectable.to_uppercase(),
+                                        );
+                                    });
+
+                            if response.clicked() {
+                                params.selected = !params.selected;
+                            }
+
+                            let response = tui.style(box_style.clone()).clickable_ext(
+                                |tui| {
+                                    tui.colored_label(
+                                        egui::Color32::WHITE,
+                                        "ext clickable transparent".to_uppercase(),
+                                    );
+                                },
+                                TuiBackground::new()
+                                    .with_background_color(egui::Color32::TRANSPARENT),
+                            );
+
+                            if response.clicked() {
+                                params.counter += 1;
+                            }
+
+                            let response = tui.style(box_style.clone()).clickable_ext(
+                                |tui| {
+                                    tui.colored_label(
+                                        egui::Color32::WHITE,
+                                        "ext clickable".to_uppercase(),
+                                    );
+                                },
+                                TuiBackground::new()
+                                    .with_border()
+                                    .with_border_width_by_response(Rc::new({
+                                        move |_, _, response| {
+                                            if response.hovered() { 10. } else { 2. }
+                                        }
+                                    }))
+                                    .with_corner_radius(20),
+                            );
+
+                            if response.clicked() {
+                                params.counter += 1;
+                            }
+
+                            let response = tui.style(box_style.clone()).clickable_ext(
+                                |tui| {
+                                    tui.colored_label(
+                                        egui::Color32::BLACK,
+                                        format!("ext {label_selectable}").to_uppercase(),
+                                    );
+                                },
+                                TuiBackground::new()
+                                    .with_background_color(if params.selected {
+                                        egui::Color32::GRAY
+                                    } else {
+                                        egui::Color32::LIGHT_GRAY
+                                    })
+                                    .with_border_color_by_response(Rc::new({
+                                        move |_, _, response| {
+                                            if response.hovered() {
+                                                egui::Color32::DARK_GRAY
+                                            } else {
+                                                egui::Color32::WHITE
+                                            }
+                                        }
+                                    }))
+                                    .with_border_width_by_response(Rc::new({
+                                        move |_, _, response| {
+                                            if response.hovered() { 10. } else { 20. }
+                                        }
+                                    }))
+                                    .with_corner_radius(200),
+                            );
+
+                            if response.clicked() {
+                                params.selected = !params.selected;
+                            }
+                        },
+                        egui::Color32::BLACK,
+                    );
+                    tui.style(taffy::Style {
+                        flex_direction: taffy::FlexDirection::Row,
+                        gap: length(20.),
+                        ..Default::default()
+                    })
+                    .add(|tui| {
+                        tui.label(format!("clicked: {}x", params.counter).to_uppercase());
+
+                        tui.add(|tui| {
+                            tui.label(format!("selected: {}", params.selected).to_uppercase())
+                        });
+                    });
+                })
         });
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,8 +4,10 @@
 
 use std::collections::HashMap;
 use std::ops::{Deref, DerefMut};
+use std::rc::Rc;
 use std::sync::Arc;
 
+use egui::style::{Visuals, WidgetVisuals};
 use egui::util::IdTypeMap;
 use egui::{Pos2, Response, Ui, UiBuilder};
 use parking_lot::{ArcMutexGuard, RawMutex};
@@ -1251,6 +1253,293 @@ where
     // Use default implementation
 }
 
+/// Getter function to get values defined by [`egui::style::Visuals`] and [`egui::style::WidgetVisuals`]
+type VisualsGetterFn<T> = Rc<dyn Fn(&Visuals, &WidgetVisuals) -> T>;
+/// Getter function to get values defined by [`egui::style::Visuals`] and [`egui::style::WidgetVisuals`]
+/// It includes a reference to [`egui::Response`] to handle widget states
+type VisualsResponseGetterFn<T> = Rc<dyn Fn(&Visuals, &WidgetVisuals, &Response) -> T>;
+
+/// Generic structure of values to draw a background by [`TuiBackground`]
+#[derive(Clone)]
+enum TuiBackgroundValue<T> {
+    /// Custom value
+    Custom(T),
+    /// Value defined by [`egui::style::Visuals`] accessible by a getter function
+    Visuals(VisualsGetterFn<T>),
+    /// Value depending on [`egui::Visuals`] accessible by a getter function
+    VisualsResponse(VisualsResponseGetterFn<T>),
+}
+
+#[derive(Clone)]
+struct TuiBackgroundBorder {
+    color: TuiBackgroundValue<egui::Color32>,
+    width: TuiBackgroundValue<f32>,
+}
+
+impl Default for TuiBackgroundBorder {
+    fn default() -> Self {
+        Self {
+            color: TuiBackgroundValue::Visuals(Rc::new(|_, widget_visuals| {
+                widget_visuals.bg_stroke.color
+            })),
+            width: TuiBackgroundValue::Visuals(Rc::new(|_, widget_visuals| {
+                widget_visuals.bg_stroke.width
+            })),
+        }
+    }
+}
+
+/// Helper to draw background fills and borders
+#[derive(Clone)]
+pub struct TuiBackground {
+    background_color: TuiBackgroundValue<egui::Color32>,
+    corner_radius: TuiBackgroundValue<egui::CornerRadius>,
+    border: Option<TuiBackgroundBorder>,
+}
+
+impl Default for TuiBackground {
+    fn default() -> Self {
+        Self {
+            background_color: TuiBackgroundValue::Visuals(Rc::new(|visuals, _| visuals.panel_fill)),
+            corner_radius: TuiBackgroundValue::Visuals(Rc::new(|_, widget_visuals| {
+                widget_visuals.corner_radius
+            })),
+            border: None,
+        }
+    }
+}
+
+impl TuiBackground {
+    /// Creates a new instance drawing a default background only
+    pub fn new() -> Self {
+        Self {
+            ..Default::default()
+        }
+    }
+
+    /// Draws background by given [`egui::Color32`]
+    pub fn with_background_color(self, background_color: egui::Color32) -> Self {
+        Self {
+            background_color: TuiBackgroundValue::Custom(background_color),
+            ..self
+        }
+    }
+
+    /// Draws background color defined by [`egui::style::Visuals`]
+    pub fn with_background_color_by_visuals(self, f: VisualsGetterFn<egui::Color32>) -> Self {
+        Self {
+            background_color: TuiBackgroundValue::Visuals(f),
+            ..self
+        }
+    }
+
+    /// Draws background color depending on [`VisualsResponseGetterFn`]
+    pub fn with_background_color_by_response(
+        self,
+        f: VisualsResponseGetterFn<egui::Color32>,
+    ) -> Self {
+        Self {
+            background_color: TuiBackgroundValue::VisualsResponse(f),
+            ..self
+        }
+    }
+
+    /// Draws default border
+    pub fn with_border(self) -> Self {
+        Self {
+            border: Some(TuiBackgroundBorder::default()),
+            ..self
+        }
+    }
+
+    /// Draws a border by given [`egui::Color32`]
+    pub fn with_border_color(self, color: egui::Color32) -> Self {
+        Self {
+            border: Some(TuiBackgroundBorder {
+                color: TuiBackgroundValue::Custom(color),
+                width: self
+                    .border
+                    .map(|b| b.width)
+                    .unwrap_or(TuiBackgroundBorder::default().width),
+            }),
+            ..self
+        }
+    }
+
+    /// Draws a border color defined by [`VisualsGetterFn`]
+    pub fn with_border_color_by_visuals(self, f: VisualsGetterFn<egui::Color32>) -> Self {
+        Self {
+            border: Some(TuiBackgroundBorder {
+                color: TuiBackgroundValue::Visuals(f),
+                width: self
+                    .border
+                    .map(|b| b.width)
+                    .unwrap_or(TuiBackgroundBorder::default().width),
+            }),
+            ..self
+        }
+    }
+
+    /// Draws a border color defined by [`VisualsResponseGetterFn`]
+    pub fn with_border_color_by_response(self, f: VisualsResponseGetterFn<egui::Color32>) -> Self {
+        Self {
+            border: Some(TuiBackgroundBorder {
+                color: TuiBackgroundValue::VisualsResponse(f),
+                width: self
+                    .border
+                    .map(|b| b.width)
+                    .unwrap_or(TuiBackgroundBorder::default().width),
+            }),
+            ..self
+        }
+    }
+
+    /// Draws border with given width
+    pub fn with_border_width(self, width: f32) -> Self {
+        Self {
+            border: Some(TuiBackgroundBorder {
+                width: TuiBackgroundValue::Custom(width),
+                color: self
+                    .border
+                    .map(|b| b.color)
+                    .unwrap_or_else(|| TuiBackgroundBorder::default().color),
+            }),
+            ..self
+        }
+    }
+
+    /// Draws a border width defined by [`VisualsGetterFn`]
+    pub fn with_border_width_by_visuals(self, f: VisualsGetterFn<f32>) -> Self {
+        Self {
+            border: Some(TuiBackgroundBorder {
+                width: TuiBackgroundValue::Visuals(f),
+                color: self
+                    .border
+                    .map(|b| b.color)
+                    .unwrap_or_else(|| TuiBackgroundBorder::default().color),
+            }),
+            ..self
+        }
+    }
+
+    /// Draws a border width defined by [`VisualsResponseGetterFn`]
+    pub fn with_border_width_by_response(self, f: VisualsResponseGetterFn<f32>) -> Self {
+        Self {
+            border: Some(TuiBackgroundBorder {
+                width: TuiBackgroundValue::VisualsResponse(f),
+                color: self
+                    .border
+                    .map(|b| b.color)
+                    .unwrap_or_else(|| TuiBackgroundBorder::default().color),
+            }),
+            ..self
+        }
+    }
+
+    /// Draws corner radius with given radius
+    pub fn with_corner_radius(self, radius: impl Into<egui::CornerRadius>) -> Self {
+        Self {
+            corner_radius: TuiBackgroundValue::Custom(radius.into()),
+            ..self
+        }
+    }
+
+    /// Draws background with given [`egui::CornerRadius`] defined by [`VisualsGetterFn`]
+    pub fn with_corner_radius_by_visuals(self, f: VisualsGetterFn<egui::CornerRadius>) -> Self {
+        Self {
+            corner_radius: TuiBackgroundValue::Visuals(f),
+            ..self
+        }
+    }
+
+    /// Draws background with given [`egui::CornerRadius`] defined by [`VisualsResponseGetterFn`]
+    pub fn with_corner_radius_by_response(
+        self,
+        f: VisualsResponseGetterFn<egui::CornerRadius>,
+    ) -> Self {
+        Self {
+            corner_radius: TuiBackgroundValue::VisualsResponse(f),
+            ..self
+        }
+    }
+
+    fn has_border(&self) -> bool {
+        self.border.is_some()
+    }
+
+    // Internal function to draw content of background.
+    fn draw_internal(
+        &self,
+        ui: &egui::Ui,
+        container: &TaffyContainerUi,
+        widget_visuals: &egui::style::WidgetVisuals,
+        response: Option<&Response>,
+    ) {
+        let rect = container.full_container();
+
+        let visuals = ui.style().visuals.clone();
+
+        // Helper to get value out from `TuiBackgroundValue`
+        fn match_value<T: Clone>(
+            visuals: &egui::style::Visuals,
+            widget_visuals: &egui::style::WidgetVisuals,
+            response: Option<&Response>,
+            value: &TuiBackgroundValue<T>,
+        ) -> T {
+            match value {
+                TuiBackgroundValue::Custom(value) => value.clone(),
+                TuiBackgroundValue::Visuals(f) => f(visuals, widget_visuals),
+                TuiBackgroundValue::VisualsResponse(f) => match response {
+                    Some(r) => f(visuals, widget_visuals, r),
+                    None => unreachable!("never called without a response"),
+                },
+            }
+        }
+        // optional fill
+        let fill = match_value(&visuals, widget_visuals, response, &self.background_color);
+
+        // optional stroke
+        let stroke = self.border.as_ref().map(|border| {
+            let color = match_value(&visuals, widget_visuals, response, &border.color);
+            let width = match_value(&visuals, widget_visuals, response, &border.width);
+            egui::Stroke { color, width }
+        });
+
+        let corner_radius = match_value(&visuals, widget_visuals, response, &self.corner_radius);
+
+        match stroke {
+            // border + fill
+            Some(stroke) => {
+                ui.painter()
+                    .rect(rect, corner_radius, fill, stroke, egui::StrokeKind::Inside);
+            }
+            // fill only
+            None => {
+                ui.painter().rect_filled(rect, corner_radius, fill);
+            }
+        }
+    }
+
+    /// Returns a draw function can be used by [`BackgroundDraw`]
+    pub fn draw(&self) -> impl FnOnce(&mut egui::Ui, &TaffyContainerUi) {
+        move |ui: &mut egui::Ui, container: &TaffyContainerUi| {
+            let widget_visuals = ui.style().visuals.noninteractive();
+            self.draw_internal(ui, container, widget_visuals, None);
+        }
+    }
+
+    /// Returns a draw function with an [`egui::Response`]
+    pub fn draw_with_response(&self) -> impl FnOnce(&mut egui::Ui, &TaffyContainerUi) -> Response {
+        move |ui: &mut egui::Ui, container: &TaffyContainerUi| {
+            let rect = container.full_container();
+            let response = ui.interact(rect, ui.id().with("bg"), egui::Sense::click());
+            let widget_visuals = ui.style().interact(&response);
+            self.draw_internal(ui, container, widget_visuals, Some(&response));
+            response
+        }
+    }
+}
+
 ////////////////////////////////////////////////////////////////////////////////
 
 /// Trait that implements TuiBuilder logic for child node creation in Tui UI.
@@ -1388,54 +1677,38 @@ pub trait TuiBuilderLogic<'r>: AsTuiBuilder<'r> + Sized {
         self.tui().add(|_| {})
     }
 
-    /// Add tui node as children to this node and draw only background color
-    #[inline]
-    fn add_with_background_color<T>(self, f: impl FnOnce(&mut Tui) -> T) -> T {
-        let tui = self.tui();
-
-        fn background(ui: &mut egui::Ui, container: &TaffyContainerUi) {
-            // TODO: Expand added to fill rounded gaps between elements
-            // How to correctly fill space between elements?
-            let rect = container.full_container().expand(1.);
-
-            let _response = ui.interact(rect, ui.id().with("bg"), egui::Sense::click_and_drag());
-            // Background is not transparent to events
-
-            let visuals = ui.style().visuals.noninteractive();
-            let window_fill = ui.style().visuals.panel_fill;
-
-            ui.painter()
-                .rect_filled(rect, visuals.corner_radius, window_fill);
-        }
-
-        tui.add_with_background_ui(background, |tui, _| f(tui)).main
-    }
-
-    /// Add tui node as children to this node and draw popup background
+    /// Add tui node as children to this node and draw a background
     #[inline]
     fn add_with_background<T>(self, f: impl FnOnce(&mut Tui) -> T) -> T {
+        let tui = self.tui();
+        let return_values =
+            tui.add_with_background_ui(TuiBackground::new().draw(), |tui, _| f(tui));
+        return_values.main
+    }
+
+    /// Add tui node as children to this node and draw a background with custom color
+    #[inline]
+    fn add_with_background_color<T>(
+        self,
+        f: impl FnOnce(&mut Tui) -> T,
+        background_color: egui::Color32,
+    ) -> T {
+        let tui = self.tui();
+        let return_values = tui.add_with_background_ui(
+            TuiBackground::new()
+                .with_background_color(background_color)
+                .draw(),
+            |tui, _| f(tui),
+        );
+        return_values.main
+    }
+
+    /// Add tui node as children to this node and draw a bordered background
+    #[inline]
+    fn add_with_background_bordered<T>(self, f: impl FnOnce(&mut Tui) -> T) -> T {
         let tui = self.tui().with_border_style_from_egui_style();
-
-        fn background(ui: &mut egui::Ui, container: &TaffyContainerUi) {
-            let rect = container.full_container();
-
-            let _response = ui.interact(rect, ui.id().with("bg"), egui::Sense::click_and_drag());
-            // Background is not transparent to events
-
-            let visuals = ui.style().visuals.noninteractive();
-            let window_fill = ui.style().visuals.panel_fill;
-
-            let stroke = visuals.bg_stroke;
-            ui.painter().rect(
-                rect,
-                visuals.corner_radius,
-                window_fill,
-                stroke,
-                egui::StrokeKind::Inside,
-            );
-        }
-
-        let return_values = tui.add_with_background_ui(background, |tui, _| f(tui));
+        let return_values =
+            tui.add_with_background_ui(TuiBackground::new().with_border().draw(), |tui, _| f(tui));
         return_values.main
     }
 
@@ -1445,59 +1718,78 @@ pub trait TuiBuilderLogic<'r>: AsTuiBuilder<'r> + Sized {
     fn with_border_style_from_egui_style(self) -> TuiBuilder<'r> {
         let tui = self.tui();
         let border = tui.tui.egui_ui().style().noninteractive().bg_stroke.width;
-        let tui = tui.mut_style(|style| {
+        tui.mut_style(|style| {
             // Allocate space for border in layout
             if style.border == Rect::zero() {
                 style.border = length(border);
             }
-        });
-        tui
+        })
     }
 
     /// Add tui node as children to this node and draw simple group Frame background
     #[inline]
     fn add_with_border<T>(self, f: impl FnOnce(&mut Tui) -> T) -> T {
-        fn background(ui: &mut egui::Ui, container: &TaffyContainerUi) {
-            let visuals = ui.style().noninteractive();
-            let rect = container.full_container();
-
-            // Background is transparent to events
-            let stroke = visuals.bg_stroke;
-            ui.painter().rect_stroke(
-                rect,
-                visuals.corner_radius,
-                stroke,
-                egui::StrokeKind::Inside,
-            );
-        }
-
         let return_values = self
             .with_border_style_from_egui_style()
-            .add_with_background_ui(background, |tui, _| f(tui));
+            .add_with_background_ui(TuiBackground::new().with_border().draw(), |tui, _| f(tui));
         return_values.main
     }
 
-    /// Add tui node with background that acts egui Collapsing header
-    #[must_use = "You should check if the user clicked this with `if ….clicked() { … } "]
-    fn clickable<T>(self, f: impl FnOnce(&mut Tui) -> T) -> TuiInnerResponse<T> {
+    /// Add tui node as children to this node and draw a custom background and/or a custom border
+    /// defined by given [`TuiBackground`]
+    ///
+    /// Use this function if you want to have full control of [`TuiBackground`] values
+    #[inline]
+    fn add_with_background_ext<T>(
+        self,
+        f: impl FnOnce(&mut Tui) -> T,
+        background: TuiBackground,
+    ) -> T {
         let tui = self.tui();
+        tui.tui
+            .add_child(tui.params, background.draw(), |tui, _| f(tui))
+            .main
+    }
 
-        fn background(ui: &mut egui::Ui, container: &TaffyContainerUi) -> Response {
-            let rect = container.full_container();
-            ui.interact(rect, ui.id().with("bg"), egui::Sense::click())
-        }
+    /// Add tui node with a custom background that is clickable
+    ///
+    /// Use this function if you want to have full control of [`TuiBackground`] values
+    #[must_use = "You should check if the user clicked this with `if ….clicked() { … } "]
+    #[inline]
+    fn clickable_ext<T>(
+        self,
+        f: impl FnOnce(&mut Tui) -> T,
+        background: TuiBackground,
+    ) -> TuiInnerResponse<T> {
+        let tui = if background.has_border() {
+            self.with_border_style_from_egui_style()
+        } else {
+            self.tui()
+        };
 
-        let return_values = tui
-            .tui
-            .add_child(tui.params, background, |tui, bg_response| {
+        let return_values = tui.tui.add_child(
+            tui.params,
+            background.draw_with_response(),
+            |tui, bg_response| {
                 setup_tui_visuals(tui, bg_response);
                 f(tui)
-            });
+            },
+        );
 
         TuiInnerResponse {
             inner: return_values.main,
             response: return_values.background,
         }
+    }
+
+    /// Add tui node with a transparent background that is clickable
+    /// Use `clickable_ext` to style background and / or borders
+    #[must_use = "You should check if the user clicked this with `if ….clicked() { … } "]
+    fn clickable<T>(self, f: impl FnOnce(&mut Tui) -> T) -> TuiInnerResponse<T> {
+        self.clickable_ext(
+            f,
+            TuiBackground::new().with_background_color(egui::Color32::TRANSPARENT),
+        )
     }
 
     /// Add tui node with background that acts as egui button
@@ -1508,50 +1800,20 @@ pub trait TuiBuilderLogic<'r>: AsTuiBuilder<'r> + Sized {
         target_tint_color: Option<egui::Color32>,
         f: impl FnOnce(&mut Tui) -> T,
     ) -> TuiInnerResponse<T> {
-        let tui = self.with_border_style_from_egui_style();
-
-        fn background(
-            ui: &mut egui::Ui,
-            container: &TaffyContainerUi,
-            target_tint_color: Option<egui::Color32>,
-        ) -> Response {
-            let rect = container.full_container();
-            let response = ui.interact(rect, ui.id().with("bg"), egui::Sense::click());
-            let visuals = ui.style().interact(&response);
-
-            let stroke = visuals.bg_stroke;
-
-            let mut bg_fill = visuals.weak_bg_fill;
-            if let Some(fill) = target_tint_color {
-                bg_fill = egui::ecolor::tint_color_towards(bg_fill, fill);
+        let background_color: VisualsGetterFn<egui::Color32> = match target_tint_color {
+            None => {
+                Rc::new(|_: &Visuals, widget_visuals: &WidgetVisuals| widget_visuals.weak_bg_fill)
             }
-            ui.painter().rect(
-                rect,
-                visuals.corner_radius,
-                bg_fill,
-                stroke,
-                egui::StrokeKind::Inside,
-            );
+            Some(tint_color) => Rc::new(move |_: &Visuals, widget_visuals: &WidgetVisuals| {
+                egui::ecolor::tint_color_towards(widget_visuals.weak_bg_fill, tint_color)
+            }),
+        };
 
-            response
-        }
+        let background = TuiBackground::new()
+            .with_border()
+            .with_background_color_by_visuals(background_color);
 
-        let return_values = tui.tui.add_child(
-            tui.params,
-            |ui: &mut egui::Ui, container: &TaffyContainerUi| {
-                background(ui, container, target_tint_color)
-            },
-            |tui, bg_response| {
-                setup_tui_visuals(tui, bg_response);
-
-                f(tui)
-            },
-        );
-
-        TuiInnerResponse {
-            inner: return_values.main,
-            response: return_values.background,
-        }
+        self.clickable_ext(f, background)
     }
 
     /// Add tui node with background that acts as egui button
@@ -1565,44 +1827,22 @@ pub trait TuiBuilderLogic<'r>: AsTuiBuilder<'r> + Sized {
     #[must_use = "You should check if the user clicked this with `if ….clicked() { … } "]
     #[inline]
     fn selectable<T>(self, selected: bool, f: impl FnOnce(&mut Tui) -> T) -> TuiInnerResponse<T> {
-        let tui = self.with_border_style_from_egui_style();
-
-        fn background(ui: &mut egui::Ui, container: &TaffyContainerUi, selected: bool) -> Response {
-            let rect = container.full_container();
-            let response = ui.interact(rect, ui.id().with("bg"), egui::Sense::click());
-
-            let mut visuals = ui.style().interact_selectable(&response, selected);
-
-            if response.hovered() && selected {
-                // Add visual effect even if button is selected
-                visuals.weak_bg_fill = ui.style().visuals.gray_out(visuals.weak_bg_fill);
-            }
-
-            let stroke = visuals.bg_stroke;
-            ui.painter().rect(
-                rect,
-                visuals.corner_radius,
-                visuals.weak_bg_fill,
-                stroke,
-                egui::StrokeKind::Inside,
-            );
-
-            response
-        }
-
-        let return_values = tui.tui.add_child(
-            tui.params,
-            |ui: &mut egui::Ui, container: &TaffyContainerUi| background(ui, container, selected),
-            |tui, bg_response| {
-                setup_tui_visuals(tui, bg_response);
-                f(tui)
+        let background_color = Rc::new(
+            move |visuals: &Visuals, widget_visuals: &WidgetVisuals, response: &Response| {
+                if response.hovered() && selected {
+                    // Add visual effect even if button is selected
+                    visuals.gray_out(widget_visuals.weak_bg_fill)
+                } else {
+                    widget_visuals.weak_bg_fill
+                }
             },
         );
 
-        TuiInnerResponse {
-            inner: return_values.main,
-            response: return_values.background,
-        }
+        let background = TuiBackground::new()
+            .with_border()
+            .with_background_color_by_response(background_color);
+
+        self.clickable_ext(f, background)
     }
 
     /// Add tui node as children to this node and draw custom background
@@ -1632,7 +1872,7 @@ pub trait TuiBuilderLogic<'r>: AsTuiBuilder<'r> + Sized {
             }
         });
 
-        tui.add_with_background(move |tui| {
+        tui.add_with_background_bordered(move |tui| {
             let s = LengthPercentageAuto::Length(
                 0.3 * tui.ui.text_style_height(&egui::TextStyle::Body),
             );
@@ -1942,7 +2182,7 @@ pub fn setup_tui_visuals(tui: &mut Tui, bg_response: &Response) {
     let style = tui.ui.style();
     let visuals = &style.visuals.widgets;
 
-    // See `[egui::Visuals::style]`
+    // See `[egui::style::Visuals]`
     let (cache_key, visuals) = if !response.sense.interactive() {
         // Nothing to change, fast exit to avoid unnecessary copies of egui::Style
         (


### PR DESCRIPTION
## Problem

Currently areas can be styled by setting or overriding values of `egui::style::Visuals`, similar how `Grid` demo it does: https://github.com/PPakalns/egui_taffy/blob/7c75b668c1076a85cd5c59c44e089437666224f9/examples/demo.rs#L700-L702 

<img width="685" height="120" alt="bg_before" src="https://github.com/user-attachments/assets/277a6550-49c4-41ad-b67b-eadcdd561da3" />

What about to have **different styles to different areas** something like that?

<img width="685" height="120" alt="bg_after" src="https://github.com/user-attachments/assets/f38855f0-6834-4d80-8c6c-11c0734f51a6" />

## Solution

By introducing `struct TuiBackground` everything of current `background` helper functions will be done in a single place now. It provides different helper function to style everything you might want. Currently: `color`, `border(width|color)`, `radius`. For `interactive` (aka `button`/`selectable`) and `noninteractive` (`flex`, `grid`) contents. It's extendable for any other style values if needed in the future. 

Check out the `background_demo`!

<img width="1315" height="621" alt="bg_demo" src="https://github.com/user-attachments/assets/0c950860-0090-4aa2-8b9c-623be9e60160" />

## Side note

Following functions have been renamed to reflect its "goal":

- `add_with_background_color` -> `add_with_background` (a background has a default color by default)
- `add_with_background_color` still exists, but it's used to add a custom `egui::Color32`
- `add_with_background` -> `add_with_background_bordered` (it already creates a background with a border) 



